### PR TITLE
Implement validation on types that are both unions and intersections

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ const buildType = (type: ts.Type, checker: ts.TypeChecker, tags?: string[][]) =>
     const isPrimitive = isPrimitiveType(type);
     const isEnum = type.getFlags() & ts.TypeFlags.EnumLike ? true : false;
 
-    const j = {
+    return {
         type: checker.typeToString(type),
         optional: isOptional,
         union: isUnion,
@@ -83,7 +83,6 @@ const buildType = (type: ts.Type, checker: ts.TypeChecker, tags?: string[][]) =>
         tags: tags || [],
         children: isPrimitive ? undefined : typeToJson(type, checker),
     };
-    return j;
 };
 
 const buildEnumType = (type: ts.Type, checker: ts.TypeChecker) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,14 +66,16 @@ const buildType = (type: ts.Type, checker: ts.TypeChecker, tags?: string[][]) =>
     }
     const isOptional = type.getFlags() & ts.TypeFlags.Undefined ? true : false;
     const isUnion = type.getFlags() & ts.TypeFlags.Union ? true : false;
+    const isIntersection = type.getFlags() & ts.TypeFlags.Intersection ? true : false;
     const isArray = isOfTypeArray(checker, type);
     const isPrimitive = isPrimitiveType(type);
     const isEnum = type.getFlags() & ts.TypeFlags.EnumLike ? true : false;
 
-    return {
+    const j = {
         type: checker.typeToString(type),
         optional: isOptional,
         union: isUnion,
+        intersection: isIntersection,
         literal: type.isLiteral(),
         array: isArray,
         primitive: isPrimitive,
@@ -81,6 +83,7 @@ const buildType = (type: ts.Type, checker: ts.TypeChecker, tags?: string[][]) =>
         tags: tags || [],
         children: isPrimitive ? undefined : typeToJson(type, checker),
     };
+    return j;
 };
 
 const buildEnumType = (type: ts.Type, checker: ts.TypeChecker) => {
@@ -109,7 +112,7 @@ const buildEnumType = (type: ts.Type, checker: ts.TypeChecker) => {
 
 
 function typeToJson(type: ts.Type, checker: ts.TypeChecker, tags?: string[][]): any {
-    if (type.isUnion()) {
+    if (type.isUnion() || type.isIntersection()) {
         return type.types.map((t) => buildType(t, checker, tags)).filter(c => c.type !== "undefined");
     }
 
@@ -155,6 +158,7 @@ function typeToJson(type: ts.Type, checker: ts.TypeChecker, tags?: string[][]): 
         const typeName = checker.typeToString(propType);
         const isOptional = prop.getFlags() & ts.SymbolFlags.Optional ? true : false;
         const isUnion = propType.getFlags() & ts.TypeFlags.Union ? true : false;
+        const isIntersection = propType.getFlags() & ts.TypeFlags.Intersection ? true : false;
         const isArray = isOfTypeArray(checker, propType) || checker.isArrayType(propType);
         const isPrimitive = isPrimitiveType(propType) || typeName === "boolean";
         const isEnum = propType.getFlags() & ts.TypeFlags.EnumLike ? true : false;
@@ -163,6 +167,7 @@ function typeToJson(type: ts.Type, checker: ts.TypeChecker, tags?: string[][]): 
             type: typeName,
             optional: isOptional,
             union: isUnion,
+            intersection: isIntersection,
             literal: propType.isLiteral(),
             array: isArray,
             primitive: isPrimitive,

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -38,8 +38,6 @@ export const createCustomValidate = (tags?: {
     };
 
     const validateUnion = (json: Array<JsonType>, input: any) => {
-        console.log("VALIDATING UNION: ", json);
-
         const valid = true;
         if (json.includes(input)) {
             return valid;
@@ -51,14 +49,10 @@ export const createCustomValidate = (tags?: {
             }
 
             if (validateJsonType(schema, input, true)) {
-                console.log("it ok", schema);
                 return true;
             }
 
-            console.log("false!");
         }
-
-        console.log("BOUTTA THROW: ", json);
 
         optionalThrow(`Literal type mismatch, expected one of [${json.map(s => s.children)}] but got [${input}]`);
         return false;
@@ -154,7 +148,6 @@ export const createCustomValidate = (tags?: {
         if (literal) {
             if (input !== children) {
                 if (!fromUnion) {
-                    console.log("THROW: ", json);
                     optionalThrow(`Literal type mismatch, expected one of [${json.children}] but got [${input}]`);
                 }
 
@@ -175,7 +168,6 @@ export const createCustomValidate = (tags?: {
         }
 
         if (array && children && children.length) {
-            console.log(json.type, "array");
             if (!validateArray(children as unknown as JsonType[], input)) {
                 return false;
             }
@@ -183,7 +175,6 @@ export const createCustomValidate = (tags?: {
         }
 
         if (intersection && children && children.length) {
-            console.log(json.type, "intersection");
             if (!validateIntersection(children as unknown as JsonType[], input)) {
                 return false;
             }
@@ -191,7 +182,6 @@ export const createCustomValidate = (tags?: {
         }
 
         if (union && children && children.length) {
-            console.log(json.type, "union");
             if (!validateUnion(children as unknown as JsonType[], input)) {
                 return false;
             }
@@ -199,7 +189,6 @@ export const createCustomValidate = (tags?: {
         }
 
         if (children && typeof children === "object" && !union && !intersection && !primitive && !array) {
-            console.log(json.type, "object");
             if (!validateObject(children as JsonSchema, input)) {
                 return false;
             }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -5,6 +5,7 @@ type JsonType = {
     type: string;
     optional: boolean;
     union: boolean;
+    intersection: boolean;
     literal: boolean;
     array: boolean;
     primitive: boolean;
@@ -37,35 +38,42 @@ export const createCustomValidate = (tags?: {
     };
 
     const validateUnion = (json: Array<JsonType>, input: any) => {
+        console.log("VALIDATING UNION: ", json);
+
         const valid = true;
         if (json.includes(input)) {
             return valid;
         }
-    
+
         for (const schema of json) {
             if (typeof schema !== "object") {
                 continue;
             }
-    
+
             if (validateJsonType(schema, input, true)) {
+                console.log("it ok", schema);
                 return true;
             }
+
+            console.log("false!");
         }
-    
+
+        console.log("BOUTTA THROW: ", json);
+
         optionalThrow(`Literal type mismatch, expected one of [${json.map(s => s.children)}] but got [${input}]`);
         return false;
     };
-    
+
     const validateArray = (json: Array<JsonType>, input: any) => {
         if (!Array.isArray(input)) {
             optionalThrow(`Expected an array and got [${typeof input}]`);
             return false;
         }
-    
+
         if (!json.length && !input.length) {
             return true;
         }
-    
+
         if (json.length === 1) {
             for (const item of input) {
                 if (!validateJsonType(json[0], item)) {
@@ -74,103 +82,133 @@ export const createCustomValidate = (tags?: {
             }
             return true;
         }
-    
+
         for (const item of input) {
             if (!validateUnion(json, item)) {
                 return false;
             }
         }
-    
+
         return true;
     };
-    
-    
+
+    const validateIntersection = (json: Array<JsonType>, input: any) => {
+        if (json.length < 2) {
+            optionalThrow(`Intersection types must have >= 2 children, got ${json.length} children!`);
+            return false;
+        }
+
+        for (const childValidation of json) {
+
+            if (!validateJsonType(childValidation, input)) {
+                console.log("intersection failed validate on schema", childValidation, " on input ", input);
+                return false;
+            }
+        }
+
+        return true;
+    };
+
+
     const validateObject = (json: JsonSchema, input: any) => {
         const requiredKeys = getAllRequiredKeys(json);
-    
+
         for (const key of requiredKeys) {
             if (!input.hasOwnProperty(key)) {
                 optionalThrow(`Object doesn't have expected property [${key}], it has the following keys - ${Object.keys(input)}`);
                 return false;
             }
         }
-    
+
         for (const key of Object.keys(input)) {
             const val = input[key];
             const schema = json[key];
-    
+
             if (!schema) {
                 continue;
             }
-    
+
             if (!validateJsonType(schema, val)) {
                 return false;
             }
         }
-    
+
         return true;
     };
-    
+
     const validateJsonType = (json: JsonType, input: any, fromUnion = false) => {
-        const { type, optional, union, tags, children, array, primitive, literal } = json;
-    
+        const { type, optional, union, intersection, tags, children, array, primitive, literal } = json;
+
         if (optional && (input === undefined || input === null)) {
             return true;
         }
-    
+
         if (optional && children && children.length) {
             if (!validateJsonType(children[0], input, fromUnion)) {
                 return false;
             }
-    
+
             return true;
         }
-    
+
         if (literal) {
             if (input !== children) {
                 if (!fromUnion) {
+                    console.log("THROW: ", json);
                     optionalThrow(`Literal type mismatch, expected one of [${json.children}] but got [${input}]`);
                 }
-                
+
                 return false;
             }
             return true;
         }
-    
+
         if (primitive) {
             if (!validators[type]) {
                 return true;
             }
-    
+
             if (!validators[type](input, tags, throwError)) {
                 return false;
             }
             return true;
         }
-    
+
         if (array && children && children.length) {
+            console.log(json.type, "array");
             if (!validateArray(children as unknown as JsonType[], input)) {
                 return false;
             }
             return true;
         }
-    
+
+        if (intersection && children && children.length) {
+            console.log(json.type, "intersection");
+            if (!validateIntersection(children as unknown as JsonType[], input)) {
+                return false;
+            }
+            return true;
+        }
+
         if (union && children && children.length) {
+            console.log(json.type, "union");
             if (!validateUnion(children as unknown as JsonType[], input)) {
                 return false;
             }
             return true;
         }
-        if (children && typeof children === "object" && !union && !primitive && !array) {
+
+        if (children && typeof children === "object" && !union && !intersection && !primitive && !array) {
+            console.log(json.type, "object");
             if (!validateObject(children as JsonSchema, input)) {
                 return false;
             }
             return true;
         }
-    
+
         return true;
     };
-    
+
     const validate = <T>(json: string) => {
         const obj = JSON.parse(json) as JsonType;
 

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -408,7 +408,7 @@ describe('Test type tags', () => {
 
         expect(PersonValidator({ name: 'Francisco', company: {name: 'Some', employees: 10, public: true}, age: -1 })).toBe(false);
     });
-    
+
     test('Custom validator', () => {
         type Company = {
             name: string;
@@ -449,7 +449,7 @@ describe('Test type tags', () => {
 
         expect(PersonValidator({ name: 'Francisco', company: {name: 'Some', employees: 10, public: true}, age: -1 })).toBe(false);
     });
-    
+
     test('Custom validator that throws', () => {
         type Company = {
             name: string;
@@ -535,7 +535,7 @@ describe('Test type tags', () => {
         expect(() => PersonValidator({id: 'abcdefghi', age: 289, height: 186})).toThrowError(new Error(`ValidationError on tag [max] with error message: \nNo human on earth has reached beyond 150 years old and you provided [289].`));
         expect(() => PersonValidator({id: 'abcdefghi', age: -1, height: 186})).toThrowError(new Error(`ValidationError on tag [min] with error message: \nA person cannot be less than 0 years old yet.`));
     });
-    
+
     test('Error description tag for custom tags', () => {
         type Person = {
             /**
@@ -547,7 +547,7 @@ describe('Test type tags', () => {
             id: number;
         };
 
-        const validate = createCustomValidate({ 
+        const validate = createCustomValidate({
             number: {
                 just9: (value: number) => value === 9
             }

--- a/tests/validations/string.test.ts
+++ b/tests/validations/string.test.ts
@@ -111,6 +111,73 @@ describe('Test string tags', () => {
         expect(TestEmailValidator({ email: 'QA[icon]CHOCOLATE[icon]@test.com' })).toBe(false);
     });
 
+    test('union and intersection', () => {
+        type TestUnionEmail = {
+            /**
+             * @email
+             */
+            emailOrAlphanumeric: string;
+        }
+
+        type TestUnionAlphanumeric = {
+            /**
+             * @alphanumeric
+             */
+            emailOrAlphanumeric: string;
+        }
+
+        // type TestUnionIntersection = TestUnionAlphanumeric & {
+        //   /**
+        //    * @min 1
+        //    * @max 5
+        //    */
+        //   other: string;
+        // }
+
+        // type TestUnionIntersection = TestUnionEmail & {
+        //   /**
+        //    * @min 1
+        //    * @max 5
+        //    */
+        //   other: string;
+        // }
+
+        type TestUnionIntersection = (TestUnionEmail | TestUnionAlphanumeric) & {
+            /**
+             * @min 1
+             * @max 5
+             */
+            other: string;
+        };
+
+        //  type TestUnionIntersection = (TestUnionEmail & {
+        //     /**
+        //      * @min 1
+        //      * @max 5
+        //      */
+        //     other: string;
+        // }) | (TestUnionAlphanumeric & {
+        //     /**
+        //      * @min 1
+        //      * @max 5
+        //      */
+        //     other: string;
+        // });
+
+        const TestUnionIntersectionValidator = validate<TestUnionIntersection>($schema<TestUnionIntersection>());
+
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'simple@example.com', other: "str" })).toBe(true);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'very.common@example.com', other: "FAILS_REALLY_LONG_STRING" })).toBe(false);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'Abc.example.com', other: "str" })).toBe(false);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'A@b@c@example.com', other: "FAILS_REALLY_LONG_STRING" })).toBe(false);
+
+        // ALPHANUMERIC TESTS
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'abc123', other: "str" })).toBe(true);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: '_', other: "str" })).toBe(false);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'abc123', other: "FAILS_REALLY_LONG_STRING" })).toBe(false);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: '_', other: "FAILS_REALLY_LONG_STRING" })).toBe(false);
+    });
+
     test('union', () => {
         type TestUnionEmail = {
             /**

--- a/tests/validations/string.test.ts
+++ b/tests/validations/string.test.ts
@@ -126,22 +126,6 @@ describe('Test string tags', () => {
             emailOrAlphanumeric: string;
         }
 
-        // type TestUnionIntersection = TestUnionAlphanumeric & {
-        //   /**
-        //    * @min 1
-        //    * @max 5
-        //    */
-        //   other: string;
-        // }
-
-        // type TestUnionIntersection = TestUnionEmail & {
-        //   /**
-        //    * @min 1
-        //    * @max 5
-        //    */
-        //   other: string;
-        // }
-
         type TestUnionIntersection = (TestUnionEmail | TestUnionAlphanumeric) & {
             /**
              * @min 1
@@ -149,20 +133,6 @@ describe('Test string tags', () => {
              */
             other: string;
         };
-
-        //  type TestUnionIntersection = (TestUnionEmail & {
-        //     /**
-        //      * @min 1
-        //      * @max 5
-        //      */
-        //     other: string;
-        // }) | (TestUnionAlphanumeric & {
-        //     /**
-        //      * @min 1
-        //      * @max 5
-        //      */
-        //     other: string;
-        // });
 
         const TestUnionIntersectionValidator = validate<TestUnionIntersection>($schema<TestUnionIntersection>());
 


### PR DESCRIPTION
Fixes https://github.com/donflopez/ttype-safe/issues/26

Validate intersections by creating a new `intersection` boolean in the JsonType "AST" structure, and a new `validateIntersection`. Passes current intersections like `GenericPerson<AdvancedJob>`.