### PR TITLE
FEAT(IR): Replace intermediate representation with JSONSchema for stability.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 lerna-debug.log*
 examples/**
 
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ yarn-error.log*
 lerna-debug.log*
 examples/**
 
-
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/docs/src/components/HomepageFeatures/index.js
+++ b/docs/src/components/HomepageFeatures/index.js
@@ -1,0 +1,52 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const react_1 = require("react");
+const clsx_1 = require("clsx");
+const styles_module_css_1 = require("./styles.module.css");
+const FeatureList = [
+    {
+        title: 'Easy to Use',
+        Svg: require('@site/static/img/undraw_docusaurus_mountain.svg').default,
+        description: (<>
+        Docusaurus was designed from the ground up to be easily installed and
+        used to get your website up and running quickly.
+      </>),
+    },
+    {
+        title: 'Focus on What Matters',
+        Svg: require('@site/static/img/undraw_docusaurus_tree.svg').default,
+        description: (<>
+        Docusaurus lets you focus on your docs, and we&apos;ll do the chores. Go
+        ahead and move your docs into the <code>docs</code> directory.
+      </>),
+    },
+    {
+        title: 'Powered by React',
+        Svg: require('@site/static/img/undraw_docusaurus_react.svg').default,
+        description: (<>
+        Extend or customize your website layout by reusing React. Docusaurus can
+        be extended while reusing the same header and footer.
+      </>),
+    },
+];
+function Feature({ title, Svg, description }) {
+    return (<div className={(0, clsx_1.default)('col col--4')}>
+      <div className="text--center">
+        <Svg className={styles_module_css_1.default.featureSvg} role="img"/>
+      </div>
+      <div className="text--center padding-horiz--md">
+        <h3>{title}</h3>
+        <p>{description}</p>
+      </div>
+    </div>);
+}
+function HomepageFeatures() {
+    return (<section className={styles_module_css_1.default.features}>
+      <div className="container">
+        <div className="row">
+          {FeatureList.map((props, idx) => (<Feature key={idx} {...props}/>))}
+        </div>
+      </div>
+    </section>);
+}
+exports.default = HomepageFeatures;

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,0 +1,33 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const react_1 = require("react");
+const clsx_1 = require("clsx");
+const Link_1 = require("@docusaurus/Link");
+const useDocusaurusContext_1 = require("@docusaurus/useDocusaurusContext");
+const Layout_1 = require("@theme/Layout");
+const HomepageFeatures_1 = require("@site/src/components/HomepageFeatures");
+const index_module_css_1 = require("./index.module.css");
+function HomepageHeader() {
+    const { siteConfig } = (0, useDocusaurusContext_1.default)();
+    return (<header className={(0, clsx_1.default)("hero hero--primary", index_module_css_1.default.heroBanner)}>
+            <div className="container">
+                <h1 className="hero__title">{siteConfig.title}</h1>
+                <p className="hero__subtitle">{siteConfig.tagline}</p>
+                <div className={index_module_css_1.default.buttons}>
+                    <Link_1.default className="button button--secondary button--lg" to="/docs/intro">
+            ttype-safe tutorial - 5min ⏱️
+                    </Link_1.default>
+                </div>
+            </div>
+        </header>);
+}
+function Home() {
+    const { siteConfig } = (0, useDocusaurusContext_1.default)();
+    return (<Layout_1.default title={`Hello from ${siteConfig.title}`} description="Description will go into a meta tag in <head />">
+            <HomepageHeader />
+            <main>
+                <HomepageFeatures_1.default />
+            </main>
+        </Layout_1.default>);
+}
+exports.default = Home;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,17 @@
 {
   "name": "ttype-safe",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ttype-safe",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "ts-json-schema-generator": "^2.5.0-next.2"
+      },
       "devDependencies": {
         "@types/jest": "^29.x",
         "@types/node": "^18.15.11",
@@ -1102,6 +1106,123 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1751,10 +1872,10 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.15.11",
@@ -2062,7 +2183,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2071,7 +2191,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2399,7 +2518,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2410,8 +2528,16 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2434,10 +2560,10 @@
       "peer": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2527,6 +2653,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.356",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.356.tgz",
@@ -2548,8 +2680,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -2983,6 +3114,34 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3298,7 +3457,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3357,8 +3515,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -3433,6 +3590,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest": {
@@ -4084,12 +4256,20 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonschema": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/kind-of": {
@@ -4274,6 +4454,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4308,7 +4497,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4405,6 +4593,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4457,7 +4651,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4467,6 +4660,31 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -4780,6 +4998,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -4799,7 +5026,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -4811,7 +5037,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4900,7 +5125,21 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4914,7 +5153,19 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5075,6 +5326,72 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-json-schema-generator": {
+      "version": "2.5.0-next.2",
+      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-2.5.0-next.2.tgz",
+      "integrity": "sha512-1WcgEymfdBKrZ0AIdmJd1WoyICV1VKSprl+XLUIqVR4zSOaDBEhPq7kgQVFg/ALw6ZopDW501WJRVm8d1uJYIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "commander": "^14.0.0",
+        "glob": "^11.0.1",
+        "json5": "^2.2.3",
+        "normalize-path": "^3.0.0",
+        "safe-stable-stringify": "^2.5.0",
+        "tslib": "^2.8.1",
+        "typescript": "^5.8.2"
+      },
+      "bin": {
+        "ts-json-schema-generator": "bin/ts-json-schema-generator.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -5204,16 +5521,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
-      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
-      "peer": true,
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -5302,7 +5619,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5327,6 +5643,24 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -6104,6 +6438,77 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="
+    },
+    "@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "requires": {
+        "@isaacs/balanced-match": "^4.0.1"
+      }
+    },
+    "@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "requires": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="
+        },
+        "ansi-styles": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -6655,10 +7060,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "@types/node": {
       "version": "18.15.11",
@@ -6851,14 +7255,12 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -7086,7 +7488,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -7094,8 +7495,12 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -7118,10 +7523,9 @@
       "peer": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -7185,6 +7589,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
     "electron-to-chromium": {
       "version": "1.4.356",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.356.tgz",
@@ -7200,8 +7609,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -7537,6 +7945,22 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "requires": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7765,8 +8189,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -7804,8 +8227,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -7864,6 +8286,14 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "requires": {
+        "@isaacs/cliui": "^8.0.2"
       }
     },
     "jest": {
@@ -8369,8 +8799,12 @@
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+    },
+    "jsonschema": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -8511,6 +8945,11 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
+    "minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8544,8 +8983,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -8612,6 +9050,11 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8648,14 +9091,29 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "requires": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+          "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A=="
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -8858,6 +9316,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="
+    },
     "semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -8871,7 +9334,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -8879,8 +9341,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "signal-exit": {
       "version": "3.0.7",
@@ -8953,7 +9414,16 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8964,7 +9434,14 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -9064,6 +9541,49 @@
         }
       }
     },
+    "ts-json-schema-generator": {
+      "version": "2.5.0-next.2",
+      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-2.5.0-next.2.tgz",
+      "integrity": "sha512-1WcgEymfdBKrZ0AIdmJd1WoyICV1VKSprl+XLUIqVR4zSOaDBEhPq7kgQVFg/ALw6ZopDW501WJRVm8d1uJYIA==",
+      "requires": {
+        "@types/json-schema": "^7.0.15",
+        "commander": "^14.0.0",
+        "glob": "^11.0.1",
+        "json5": "^2.2.3",
+        "normalize-path": "^3.0.0",
+        "safe-stable-stringify": "^2.5.0",
+        "tslib": "^2.8.1",
+        "typescript": "^5.8.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+          "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+          "requires": {
+            "foreground-child": "^3.3.1",
+            "jackspeak": "^4.1.1",
+            "minimatch": "^10.0.3",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^2.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+          "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+          "requires": {
+            "@isaacs/brace-expansion": "^5.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
     "ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -9148,10 +9668,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
-      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
-      "peer": true
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="
     },
     "update-browserslist-db": {
       "version": "1.0.10",
@@ -9222,7 +9741,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -9238,6 +9756,16 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "npx eslint",
+    "lint": "npx eslint '{src,tests}/**/*.ts'",
+    "lint:fix": "npx eslint --fix '{src,tests}/**/*.ts'",
     "test": "jest",
     "prepublishOnly": "tsc",
     "docs": "npx ts-docs",
@@ -62,5 +63,9 @@
         }
       ]
     }
+  },
+  "dependencies": {
+    "jsonschema": "^1.5.0",
+    "ts-json-schema-generator": "^2.5.0-next.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ const buildType = (type: ts.Type, checker: ts.TypeChecker, tags?: string[][]) =>
     const isPrimitive = isPrimitiveType(type);
     const isEnum = type.getFlags() & ts.TypeFlags.EnumLike ? true : false;
 
-    const j = {
+    return {
         type: checker.typeToString(type),
         optional: isOptional,
         union: isUnion,
@@ -83,7 +83,6 @@ const buildType = (type: ts.Type, checker: ts.TypeChecker, tags?: string[][]) =>
         tags: tags || [],
         children: isPrimitive ? undefined : typeToJson(type, checker),
     };
-    return j;
 };
 
 const buildEnumType = (type: ts.Type, checker: ts.TypeChecker) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,14 +66,16 @@ const buildType = (type: ts.Type, checker: ts.TypeChecker, tags?: string[][]) =>
     }
     const isOptional = type.getFlags() & ts.TypeFlags.Undefined ? true : false;
     const isUnion = type.getFlags() & ts.TypeFlags.Union ? true : false;
+    const isIntersection = type.getFlags() & ts.TypeFlags.Intersection ? true : false;
     const isArray = isOfTypeArray(checker, type);
     const isPrimitive = isPrimitiveType(type);
     const isEnum = type.getFlags() & ts.TypeFlags.EnumLike ? true : false;
 
-    return {
+    const j = {
         type: checker.typeToString(type),
         optional: isOptional,
         union: isUnion,
+        intersection: isIntersection,
         literal: type.isLiteral(),
         array: isArray,
         primitive: isPrimitive,
@@ -81,6 +83,7 @@ const buildType = (type: ts.Type, checker: ts.TypeChecker, tags?: string[][]) =>
         tags: tags || [],
         children: isPrimitive ? undefined : typeToJson(type, checker),
     };
+    return j;
 };
 
 const buildEnumType = (type: ts.Type, checker: ts.TypeChecker) => {
@@ -109,7 +112,7 @@ const buildEnumType = (type: ts.Type, checker: ts.TypeChecker) => {
 
 
 function typeToJson(type: ts.Type, checker: ts.TypeChecker, tags?: string[][]): any {
-    if (type.isUnion()) {
+    if (type.isUnion() || type.isIntersection()) {
         return type.types.map((t) => buildType(t, checker, tags)).filter(c => c.type !== "undefined");
     }
 
@@ -155,6 +158,7 @@ function typeToJson(type: ts.Type, checker: ts.TypeChecker, tags?: string[][]): 
         const typeName = checker.typeToString(propType);
         const isOptional = prop.getFlags() & ts.SymbolFlags.Optional ? true : false;
         const isUnion = propType.getFlags() & ts.TypeFlags.Union ? true : false;
+        const isIntersection = propType.getFlags() & ts.TypeFlags.Intersection ? true : false;
         const isArray = isOfTypeArray(checker, propType) || checker.isArrayType(propType);
         const isPrimitive = isPrimitiveType(propType) || typeName === "boolean";
         const isEnum = propType.getFlags() & ts.TypeFlags.EnumLike ? true : false;
@@ -163,6 +167,7 @@ function typeToJson(type: ts.Type, checker: ts.TypeChecker, tags?: string[][]): 
             type: typeName,
             optional: isOptional,
             union: isUnion,
+            intersection: isIntersection,
             literal: propType.isLiteral(),
             array: isArray,
             primitive: isPrimitive,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,209 +1,48 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as ts from "typescript";
 import type { TsCompilerInstance } from "ts-jest/dist/types";
+import { CompletedConfig, createFormatter, createParser, DEFAULT_CONFIG, SchemaGenerator } from "ts-json-schema-generator";
 
-const isOfTypeArray = (checker: ts.TypeChecker, type: ts.Type) => ts.isArrayTypeNode(checker.typeToTypeNode(type, undefined, undefined)!);
-
-const isPrimitiveType = (type: ts.Type): boolean => {
-    switch (type.getFlags()) {
-    case ts.TypeFlags.String:
-    case ts.TypeFlags.Number:
-    case ts.TypeFlags.Boolean:
-    case ts.TypeFlags.EnumLiteral:
-    case ts.TypeFlags.BigIntLiteral:
-    case ts.TypeFlags.ESSymbol:
-    case ts.TypeFlags.Void:
-    case ts.TypeFlags.Undefined:
-    case ts.TypeFlags.Null:
-    case ts.TypeFlags.Never:
-        return true;
-    default:
-        return false;
-    }
-};
-
-const extractJsDoc = (node: ts.PropertySignature & {
-    jsDoc: Array<{
-        tags: Array<{
-            tagName: {
-                getText: () => string
-            },
-            comment: string
-        }>
-    }>
-}) => {
-    return node.jsDoc?.flatMap((doc) => doc.tags?.map((tag) => [tag.tagName.getText(), tag.comment, node.name.getText()]));
-};
-
-const buildPrimitiveType = (type: ts.Type, checker: ts.TypeChecker, tags?: string[][]) => {
-    const isOptional = type.getFlags() & ts.TypeFlags.Undefined ? true : false;
-    const isUnion = type.getFlags() & ts.TypeFlags.Union ? true : false;
-    const isArray = isOfTypeArray(checker, type);
-    const isPrimitive = isPrimitiveType(type);
-
+const makeConfig = (): CompletedConfig => {
     return {
-        type: checker.typeToString(type),
-        optional: isOptional,
-        union: isUnion,
-        literal: type.isLiteral(),
-        array: isArray,
-        primitive: isPrimitive,
-        tags: tags || [],
+        ...DEFAULT_CONFIG,
+        "type": "*",
+        "additionalProperties": true,
+        "discriminatorType": "json-schema",
+        "encodeRefs": true,
+        "expose": "all",
+        "fullDescription": true,
+        "markdownDescription": false,
+        "functions": "hide",
+        "jsDoc": "extended",
+        "minify": true,
+        "skipTypeCheck": true,
+        "sortProps": true,
+        "strictTuples": true,
+        "topRef": true,
     };
 };
 
-const buildType = (type: ts.Type, checker: ts.TypeChecker, tags?: string[][]) => {
-    const symbol = type.getSymbol();
+export const makeTypeBuilder = (program: ts.Program) => (type: ts.Node): object => {
+    const config = makeConfig();
 
-    if (symbol) {
-        const prop = symbol.getDeclarations()![0];
-        if (prop && ts.isPropertySignature(prop)) {
-            const newTags = extractJsDoc(prop as any)?.filter((x) => x);
-            if (newTags.length) {
-                tags = newTags;
-            }
-        }
-    }
-    const isOptional = type.getFlags() & ts.TypeFlags.Undefined ? true : false;
-    const isUnion = type.getFlags() & ts.TypeFlags.Union ? true : false;
-    const isIntersection = type.getFlags() & ts.TypeFlags.Intersection ? true : false;
-    const isArray = isOfTypeArray(checker, type);
-    const isPrimitive = isPrimitiveType(type);
-    const isEnum = type.getFlags() & ts.TypeFlags.EnumLike ? true : false;
+    const gen = new SchemaGenerator(program, createParser(program, config), createFormatter(config), config);
 
-    return {
-        type: checker.typeToString(type),
-        optional: isOptional,
-        union: isUnion,
-        intersection: isIntersection,
-        literal: type.isLiteral(),
-        array: isArray,
-        primitive: isPrimitive,
-        isEnum: isEnum,
-        tags: tags || [],
-        children: isPrimitive ? undefined : typeToJson(type, checker),
-    };
+    return gen.createSchemaFromNodes([type]);
 };
-
-const buildEnumType = (type: ts.Type, checker: ts.TypeChecker) => {
-    const symbol = type.getSymbol();
-
-    if (symbol) {
-        const declaration = symbol.getDeclarations()![0];
-
-        if (ts.isEnumDeclaration(declaration)) {
-            return declaration.members.map((member) => {
-                return {
-                    type: member.name.getText(),
-                    optional: false,
-                    union: false,
-                    literal: true,
-                    array: false,
-                    primitive: false,
-                    isEnum: false,
-                    tags: [],
-                    children: checker.getConstantValue(member),
-                };
-            });
-        }
-    }
-};
-
-
-function typeToJson(type: ts.Type, checker: ts.TypeChecker, tags?: string[][]): any {
-    if (type.isUnion() || type.isIntersection()) {
-        return type.types.map((t) => buildType(t, checker, tags)).filter(c => c.type !== "undefined");
-    }
-
-    if (isPrimitiveType(type)) {
-        return buildPrimitiveType(type, checker);
-    }
-
-    const symbol = type.getSymbol() || type.aliasSymbol;
-    if (!symbol) {
-        if (type.isLiteral()) {
-            const typeName = checker.typeToString(type).replaceAll("\"", "");
-            return type.isNumberLiteral() ? JSON.parse(typeName) : typeName;
-        }
-
-        if (isPrimitiveType(type)) {
-            return buildPrimitiveType(type, checker, undefined);
-        }
-
-        return undefined;
-    }
-
-    if (isOfTypeArray(checker, type)) {
-        return (type as any).resolvedTypeArguments.map((type: any) => buildType(type, checker));
-    }
-
-    if (symbol.getName() === "Array" || checker.isArrayType(type)) {
-        // Handle arrays explicitly if not caught by the above type reference check
-        return (type as ts.TypeReference).typeArguments?.map((t) => buildType(t, checker));
-    }
-
-    const properties = checker.getPropertiesOfType(type);
-    const json: { [key: string]: any } = {};
-
-    for (const prop of properties) {
-        const x = prop.getDeclarations()![0];
-        let tags;
-        if (x && ts.isPropertySignature(x)) {
-            tags = extractJsDoc(x as any)?.filter((x) => x);
-        }
-
-        const propName = prop.getName();
-        const propType = checker.getTypeOfSymbolAtLocation(prop, symbol.getDeclarations()![0]);
-        const typeName = checker.typeToString(propType);
-        const isOptional = prop.getFlags() & ts.SymbolFlags.Optional ? true : false;
-        const isUnion = propType.getFlags() & ts.TypeFlags.Union ? true : false;
-        const isIntersection = propType.getFlags() & ts.TypeFlags.Intersection ? true : false;
-        const isArray = isOfTypeArray(checker, propType) || checker.isArrayType(propType);
-        const isPrimitive = isPrimitiveType(propType) || typeName === "boolean";
-        const isEnum = propType.getFlags() & ts.TypeFlags.EnumLike ? true : false;
-
-        json[propName] = {
-            type: typeName,
-            optional: isOptional,
-            union: isUnion,
-            intersection: isIntersection,
-            literal: propType.isLiteral(),
-            array: isArray,
-            primitive: isPrimitive,
-            enum: isEnum,
-            tags: tags || [],
-        };
-
-        if (isEnum) {
-            json[propName].children = buildEnumType(propType, checker);
-        }
-        else if (!isPrimitive) {
-            if (!isArray && checker.isArrayType(propType)) {
-                console.log("####", (propType as ts.TypeReference).typeArguments);
-
-                json[propName].children = typeToJson((propType as ts.TypeReference).typeArguments![0], checker, tags);
-            } else {
-                json[propName].children = typeToJson(propType, checker, tags);
-            }
-        }
-    }
-
-    return json;
-}
 
 const transformer = (program: ts.Program) => (context: ts.TransformationContext) => {
     const validators = new Map<string, ts.Node[]>();
 
-    const visitor: ts.Visitor = (node) => {
-        // if (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node)) {
-        //     const json = buildType(program.getTypeChecker().getTypeAtLocation(node), program.getTypeChecker());
+    const generator = makeTypeBuilder(program);
 
-        //     validators.set(node.name.text, [ts.factory.createStringLiteral(JSON.stringify(json))]);
-        // }
+    const visitor: ts.Visitor = (node) => {
 
         if (ts.isCallExpression(node) && node.expression.getText() === "$schema") {
             const type = node.typeArguments![0];
-            const json = buildType(program.getTypeChecker().getTypeAtLocation(type), program.getTypeChecker());
+
+            const json = generator(type);
+
             validators.set(node.typeArguments![0].getText(), [ts.factory.createStringLiteral(JSON.stringify(json))]);
             const validator = validators.get(type.getText());
             if (validator) {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -38,8 +38,6 @@ export const createCustomValidate = (tags?: {
     };
 
     const validateUnion = (json: Array<JsonType>, input: any) => {
-        console.log("VALIDATING UNION: ", json);
-
         const valid = true;
         if (json.includes(input)) {
             return valid;
@@ -51,14 +49,10 @@ export const createCustomValidate = (tags?: {
             }
 
             if (validateJsonType(schema, input, true)) {
-                console.log("it ok", schema);
                 return true;
             }
 
-            console.log("false!");
         }
-
-        console.log("BOUTTA THROW: ", json);
 
         optionalThrow(`Literal type mismatch, expected one of [${json.map(s => s.children)}] but got [${input}]`);
         return false;
@@ -154,7 +148,6 @@ export const createCustomValidate = (tags?: {
         if (literal) {
             if (input !== children) {
                 if (!fromUnion) {
-                    console.log("THROW: ", json);
                     optionalThrow(`Literal type mismatch, expected one of [${json.children}] but got [${input}]`);
                 }
 
@@ -175,7 +168,6 @@ export const createCustomValidate = (tags?: {
         }
 
         if (array && children && children.length) {
-            console.log(json.type, "array");
             if (!validateArray(children as unknown as JsonType[], input)) {
                 return false;
             }
@@ -183,7 +175,6 @@ export const createCustomValidate = (tags?: {
         }
 
         if (intersection && children && children.length) {
-            console.log(json.type, "intersection");
             if (!validateIntersection(children as unknown as JsonType[], input)) {
                 return false;
             }
@@ -191,7 +182,6 @@ export const createCustomValidate = (tags?: {
         }
 
         if (union && children && children.length) {
-            console.log(json.type, "union");
             if (!validateUnion(children as unknown as JsonType[], input)) {
                 return false;
             }
@@ -199,7 +189,6 @@ export const createCustomValidate = (tags?: {
         }
 
         if (children && typeof children === "object" && !union && !intersection && !primitive && !array) {
-            console.log(json.type, "object");
             if (!validateObject(children as JsonSchema, input)) {
                 return false;
             }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -5,6 +5,7 @@ type JsonType = {
     type: string;
     optional: boolean;
     union: boolean;
+    intersection: boolean;
     literal: boolean;
     array: boolean;
     primitive: boolean;
@@ -37,35 +38,42 @@ export const createCustomValidate = (tags?: {
     };
 
     const validateUnion = (json: Array<JsonType>, input: any) => {
+        console.log("VALIDATING UNION: ", json);
+
         const valid = true;
         if (json.includes(input)) {
             return valid;
         }
-    
+
         for (const schema of json) {
             if (typeof schema !== "object") {
                 continue;
             }
-    
+
             if (validateJsonType(schema, input, true)) {
+                console.log("it ok", schema);
                 return true;
             }
+
+            console.log("false!");
         }
-    
+
+        console.log("BOUTTA THROW: ", json);
+
         optionalThrow(`Literal type mismatch, expected one of [${json.map(s => s.children)}] but got [${input}]`);
         return false;
     };
-    
+
     const validateArray = (json: Array<JsonType>, input: any) => {
         if (!Array.isArray(input)) {
             optionalThrow(`Expected an array and got [${typeof input}]`);
             return false;
         }
-    
+
         if (!json.length && !input.length) {
             return true;
         }
-    
+
         if (json.length === 1) {
             for (const item of input) {
                 if (!validateJsonType(json[0], item)) {
@@ -74,103 +82,133 @@ export const createCustomValidate = (tags?: {
             }
             return true;
         }
-    
+
         for (const item of input) {
             if (!validateUnion(json, item)) {
                 return false;
             }
         }
-    
+
         return true;
     };
-    
-    
+
+    const validateIntersection = (json: Array<JsonType>, input: any) => {
+        if (json.length < 2) {
+            optionalThrow(`Intersection types must have >= 2 children, got ${json.length} children!`);
+            return false;
+        }
+
+        for (const childValidation of json) {
+
+            if (!validateJsonType(childValidation, input)) {
+                console.log("intersection failed validate on schema", childValidation, " on input ", input);
+                return false;
+            }
+        }
+
+        return true;
+    };
+
+
     const validateObject = (json: JsonSchema, input: any) => {
         const requiredKeys = getAllRequiredKeys(json);
-    
+
         for (const key of requiredKeys) {
             if (!input.hasOwnProperty(key)) {
                 optionalThrow(`Object doesn't have expected property [${key}], it has the following keys - ${Object.keys(input)}`);
                 return false;
             }
         }
-    
+
         for (const key of Object.keys(input)) {
             const val = input[key];
             const schema = json[key];
-    
+
             if (!schema) {
                 continue;
             }
-    
+
             if (!validateJsonType(schema, val)) {
                 return false;
             }
         }
-    
+
         return true;
     };
-    
+
     const validateJsonType = (json: JsonType, input: any, fromUnion = false) => {
-        const { type, optional, union, tags, children, array, primitive, literal } = json;
-    
+        const { type, optional, union, intersection, tags, children, array, primitive, literal } = json;
+
         if (optional && (input === undefined || input === null)) {
             return true;
         }
-    
+
         if (optional && children && children.length) {
             if (!validateJsonType(children[0], input, fromUnion)) {
                 return false;
             }
-    
+
             return true;
         }
-    
+
         if (literal) {
             if (input !== children) {
                 if (!fromUnion) {
+                    console.log("THROW: ", json);
                     optionalThrow(`Literal type mismatch, expected one of [${json.children}] but got [${input}]`);
                 }
-                
+
                 return false;
             }
             return true;
         }
-    
+
         if (primitive) {
             if (!validators[type]) {
                 return true;
             }
-    
+
             if (!validators[type](input, tags, throwError)) {
                 return false;
             }
             return true;
         }
-    
+
         if (array && children && children.length) {
+            console.log(json.type, "array");
             if (!validateArray(children as unknown as JsonType[], input)) {
                 return false;
             }
             return true;
         }
-    
+
+        if (intersection && children && children.length) {
+            console.log(json.type, "intersection");
+            if (!validateIntersection(children as unknown as JsonType[], input)) {
+                return false;
+            }
+            return true;
+        }
+
         if (union && children && children.length) {
+            console.log(json.type, "union");
             if (!validateUnion(children as unknown as JsonType[], input)) {
                 return false;
             }
             return true;
         }
-        if (children && typeof children === "object" && !union && !primitive && !array) {
+
+        if (children && typeof children === "object" && !union && !intersection && !primitive && !array) {
+            console.log(json.type, "object");
             if (!validateObject(children as JsonSchema, input)) {
                 return false;
             }
             return true;
         }
-    
+
         return true;
     };
-    
+
     const validate = <T>(json: string) => {
         const obj = JSON.parse(json) as JsonType;
 

--- a/src/validations/boolean.ts
+++ b/src/validations/boolean.ts
@@ -1,5 +1,0 @@
-import { createValidatorFor } from "./common";
-
-const isBoolean = (value: unknown): value is boolean => typeof value === "boolean";
-
-export const validateBoolean = createValidatorFor("boolean", isBoolean, {});

--- a/src/validations/index.ts
+++ b/src/validations/index.ts
@@ -1,20 +1,9 @@
-import { validateBoolean } from "./boolean";
-import { customNumberValidator, validateNumber } from "./number";
-import { customStringValidator, validateString } from "./string";
+export type ValidatorStructure<T> = {
+    name: string;
+    is: (x: unknown) => x is T,
+    tags: TagValidator<T>,
+}
 
-type Validators =  { [type: string]: (value: any, tags: string[][], throwError?: boolean) => boolean };
-
-export const validators: Validators = {
-    string: validateString,
-    number: validateNumber,
-    boolean: validateBoolean,
-};
-
-export type TagValidator<T> = {[tag: string]: (value: T, tagInput: string) => boolean};
-export const updateValidators = (newValidators?: { string?: TagValidator<string>, number?: TagValidator<number>}): Validators   => {
-    return {
-        ...validators,
-        string: customStringValidator(newValidators?.string || {}),
-        number: customNumberValidator(newValidators?.number || {})
-    };
+export type TagValidator<T> = {
+    [tag: string]: (value: T, tagInput: string) => boolean
 };

--- a/src/validations/number.ts
+++ b/src/validations/number.ts
@@ -1,11 +1,11 @@
-import { Tags, createValidatorFor } from "./common";
+import { ValidatorStructure } from ".";
 
-const isNumber = (x: any): x is number => typeof x === "number";
+const isNumber = (x: unknown): x is number => typeof x === "number";
 
 const TAGS = {
     /**
      * Use this tag to validate if a number is less than or equal to a given number
-     * 
+     *
      * @example
      * ```ts
      * type Ranges = {
@@ -15,15 +15,15 @@ const TAGS = {
      *   end: number;
      * }
      * ```
-     * @param value 
-     * @param max 
+     * @param value
+     * @param max
      * @returns true if value is less than or equal to max
      */
     max: (value: number, max: string) => value <= parseInt(max),
 
     /**
      * Use this tag to validate if a number is greater than or equal to a given number
-     * 
+     *
      * @example
      * ```ts
      * type Ranges = {
@@ -40,6 +40,8 @@ const TAGS = {
     min: (value: number, min: string) => value >= parseInt(min),
 };
 
-export const validateNumber = createValidatorFor("number", isNumber, TAGS);
-
-export const customNumberValidator = (tags: Tags) => createValidatorFor<number>("number", isNumber, {...TAGS, ...tags});
+export const NUMBER_VALIDATOR: ValidatorStructure<number> = {
+    name: "number",
+    is: isNumber,
+    tags: TAGS,
+};

--- a/src/validations/string.ts
+++ b/src/validations/string.ts
@@ -1,11 +1,11 @@
-import { Tags, createValidatorFor } from "./common";
+import { ValidatorStructure } from ".";
 
-const isString = (x: any): x is string => typeof x === "string";
+const isString = (x: unknown): x is string => typeof x === "string";
 
 const TAGS = {
     /**
      * Test the value of the string against the provided regex
-     * 
+     *
      * @example
      * ```ts
      * type Person = {
@@ -15,10 +15,10 @@ const TAGS = {
      *   name: string;
      * }
      * ```
-     * 
-     * @param value 
-     * @param regex 
-     * @returns 
+     *
+     * @param value
+     * @param regex
+     * @returns
      */
     regex: (value: string, regex: string) => {
         const re = new RegExp(regex.replaceAll("/", ""));
@@ -27,7 +27,7 @@ const TAGS = {
 
     /**
      * Test if the string is alphanumeric
-     * 
+     *
      * @example
      * ```ts
      * type Person = {
@@ -37,15 +37,15 @@ const TAGS = {
      * lastName: string;
      * }
      * ```
-     * 
+     *
      * @param value
-     * @returns 
+     * @returns
      */
     alphanumeric: (value: string) => TAGS.regex(value, "/^[a-zA-Z0-9]+$/"),
 
     /**
      * Test if the string is shorter than the provided length
-     * 
+     *
      * @example
      * ```ts
      * type Person = {
@@ -55,7 +55,7 @@ const TAGS = {
      * lastName: string;
      * }
      * ```
-     * 
+     *
      * @param value
      * @param length
      * @returns
@@ -64,7 +64,7 @@ const TAGS = {
 
     /**
      * Test if the string is larger than the provided length
-     * 
+     *
      * @example
      * ```ts
      * type Person = {
@@ -74,7 +74,7 @@ const TAGS = {
      * lastName: string;
      * }
      * ```
-     * 
+     *
      * @param value
      * @param length
      * @returns
@@ -121,6 +121,8 @@ const TAGS = {
     notempty: (value: string) => value !== "",
 };
 
-export const validateString = createValidatorFor("string", isString, TAGS);
-
-export const customStringValidator = (tags: Tags) => createValidatorFor<string>("string", isString, { ...TAGS, ...tags });
+export const STRING_VALIDATOR: ValidatorStructure<string> = {
+    name: "string",
+    is: isString,
+    tags: TAGS,
+} as const;

--- a/tests/enums.test.ts
+++ b/tests/enums.test.ts
@@ -1,0 +1,65 @@
+import { $schema, validate } from "../src/validation";
+
+describe("enums", () => {
+  test("Regular enums", () => {
+    enum Enum {
+      value,
+      value2
+    }
+
+    const EnumValidator = validate<Enum>($schema<Enum>());
+
+    expect(EnumValidator(Enum.value)).toBe(true);
+    expect(EnumValidator(Enum.value2)).toBe(true);
+  });
+
+  test("String enums", () => {
+    enum Enum {
+      value = "value",
+      value2 = "value-2"
+    }
+
+    const EnumValidator = validate<Enum>($schema<Enum>());
+
+    expect(EnumValidator(Enum.value)).toBe(true);
+    expect(EnumValidator(Enum.value2)).toBe(true);
+
+    expect(EnumValidator("value" as Enum)).toBe(true);
+    expect(EnumValidator("value-2" as Enum)).toBe(true);
+  });
+
+  test("Mapped enum keys", () => {
+    enum Enum {
+      value = "value",
+      value2 = "value-2"
+    }
+
+    type Mapped = Record<Enum, string>;
+
+    const MappedValidator = validate<Mapped>($schema<Mapped>());
+
+    expect(MappedValidator({ [Enum.value]: 'string', [Enum.value2]: 'other' })).toBe(true);
+    expect(MappedValidator({ value: 'string', "value-2": 'other' })).toBe(true);
+
+    expect(MappedValidator({} as Mapped)).toBe(false);
+    expect(MappedValidator({ value: 'string' } as Mapped)).toBe(false);
+  });
+
+  test("Partially mapped enum keys", () => {
+    enum Enum {
+      value = "value",
+      value2 = "value-2"
+    }
+
+    type PartialMapped = Partial<Record<Enum, string>>;
+
+    const MappedValidator = validate<PartialMapped>($schema<PartialMapped>());
+
+    expect(MappedValidator({ [Enum.value2]: 'other' })).toBe(true);
+    expect(MappedValidator({ value: 'string', "value-2": 'other' })).toBe(true);
+    expect(MappedValidator({})).toBe(true);
+    expect(MappedValidator({ value: 'string' })).toBe(true);
+
+    expect(MappedValidator({ a: 2 } as PartialMapped)).toBe(true); // unknown keys are fine
+  });
+})

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -408,7 +408,7 @@ describe('Test type tags', () => {
 
         expect(PersonValidator({ name: 'Francisco', company: {name: 'Some', employees: 10, public: true}, age: -1 })).toBe(false);
     });
-    
+
     test('Custom validator', () => {
         type Company = {
             name: string;
@@ -449,7 +449,7 @@ describe('Test type tags', () => {
 
         expect(PersonValidator({ name: 'Francisco', company: {name: 'Some', employees: 10, public: true}, age: -1 })).toBe(false);
     });
-    
+
     test('Custom validator that throws', () => {
         type Company = {
             name: string;
@@ -535,7 +535,7 @@ describe('Test type tags', () => {
         expect(() => PersonValidator({id: 'abcdefghi', age: 289, height: 186})).toThrowError(new Error(`ValidationError on tag [max] with error message: \nNo human on earth has reached beyond 150 years old and you provided [289].`));
         expect(() => PersonValidator({id: 'abcdefghi', age: -1, height: 186})).toThrowError(new Error(`ValidationError on tag [min] with error message: \nA person cannot be less than 0 years old yet.`));
     });
-    
+
     test('Error description tag for custom tags', () => {
         type Person = {
             /**
@@ -547,7 +547,7 @@ describe('Test type tags', () => {
             id: number;
         };
 
-        const validate = createCustomValidate({ 
+        const validate = createCustomValidate({
             number: {
                 just9: (value: number) => value === 9
             }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,14 +1,21 @@
 {
-    "compilerOptions": {
-      "target": "ES2021",
-      "module": "commonjs",
-      "removeComments": true,
-      "outDir": "./dist",
-      "esModuleInterop": true,
-      "strictNullChecks": true, 
-      "plugins": [
-        { "transform": "../src/index.ts" }
-      ]
-    },
-    "include": ["./integrated", "./snapshots/index.ts", "integrated/labels"]
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "removeComments": true,
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "strictNullChecks": true,
+    "plugins": [
+      {
+        "transform": "../src/index.ts"
+      }
+    ]
+  },
+  "include": [
+    "./integrated",
+    "./snapshots/index.ts",
+    "integrated/labels"
+  ]
 }

--- a/tests/validations/string.test.ts
+++ b/tests/validations/string.test.ts
@@ -111,6 +111,73 @@ describe('Test string tags', () => {
         expect(TestEmailValidator({ email: 'QA[icon]CHOCOLATE[icon]@test.com' })).toBe(false);
     });
 
+    test('union and intersection', () => {
+        type TestUnionEmail = {
+            /**
+             * @email
+             */
+            emailOrAlphanumeric: string;
+        }
+
+        type TestUnionAlphanumeric = {
+            /**
+             * @alphanumeric
+             */
+            emailOrAlphanumeric: string;
+        }
+
+        // type TestUnionIntersection = TestUnionAlphanumeric & {
+        //   /**
+        //    * @min 1
+        //    * @max 5
+        //    */
+        //   other: string;
+        // }
+
+        // type TestUnionIntersection = TestUnionEmail & {
+        //   /**
+        //    * @min 1
+        //    * @max 5
+        //    */
+        //   other: string;
+        // }
+
+        type TestUnionIntersection = (TestUnionEmail | TestUnionAlphanumeric) & {
+            /**
+             * @min 1
+             * @max 5
+             */
+            other: string;
+        };
+
+        //  type TestUnionIntersection = (TestUnionEmail & {
+        //     /**
+        //      * @min 1
+        //      * @max 5
+        //      */
+        //     other: string;
+        // }) | (TestUnionAlphanumeric & {
+        //     /**
+        //      * @min 1
+        //      * @max 5
+        //      */
+        //     other: string;
+        // });
+
+        const TestUnionIntersectionValidator = validate<TestUnionIntersection>($schema<TestUnionIntersection>());
+
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'simple@example.com', other: "str" })).toBe(true);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'very.common@example.com', other: "FAILS_REALLY_LONG_STRING" })).toBe(false);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'Abc.example.com', other: "str" })).toBe(false);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'A@b@c@example.com', other: "FAILS_REALLY_LONG_STRING" })).toBe(false);
+
+        // ALPHANUMERIC TESTS
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'abc123', other: "str" })).toBe(true);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: '_', other: "str" })).toBe(false);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: 'abc123', other: "FAILS_REALLY_LONG_STRING" })).toBe(false);
+        expect(TestUnionIntersectionValidator({ emailOrAlphanumeric: '_', other: "FAILS_REALLY_LONG_STRING" })).toBe(false);
+    });
+
     test('union', () => {
         type TestUnionEmail = {
             /**

--- a/tests/validations/string.test.ts
+++ b/tests/validations/string.test.ts
@@ -126,22 +126,6 @@ describe('Test string tags', () => {
             emailOrAlphanumeric: string;
         }
 
-        // type TestUnionIntersection = TestUnionAlphanumeric & {
-        //   /**
-        //    * @min 1
-        //    * @max 5
-        //    */
-        //   other: string;
-        // }
-
-        // type TestUnionIntersection = TestUnionEmail & {
-        //   /**
-        //    * @min 1
-        //    * @max 5
-        //    */
-        //   other: string;
-        // }
-
         type TestUnionIntersection = (TestUnionEmail | TestUnionAlphanumeric) & {
             /**
              * @min 1
@@ -149,20 +133,6 @@ describe('Test string tags', () => {
              */
             other: string;
         };
-
-        //  type TestUnionIntersection = (TestUnionEmail & {
-        //     /**
-        //      * @min 1
-        //      * @max 5
-        //      */
-        //     other: string;
-        // }) | (TestUnionAlphanumeric & {
-        //     /**
-        //      * @min 1
-        //      * @max 5
-        //      */
-        //     other: string;
-        // });
 
         const TestUnionIntersectionValidator = validate<TestUnionIntersection>($schema<TestUnionIntersection>());
 

--- a/tests/validations/string.test.ts
+++ b/tests/validations/string.test.ts
@@ -151,6 +151,7 @@ describe('Test string tags', () => {
     test('union', () => {
         type TestUnionEmail = {
             /**
+             * ignored wow@
              * @email
              */
             emailOrAlphanumeric: string;
@@ -204,21 +205,39 @@ describe('Test string tags', () => {
          expect(TestEmailOrAlphanumericValidator({ emailOrAlphanumeric: '' })).toBe(false);
     })
 
-    test('notempty', () => {
-        type TestNotempty = {
-            /**
-             * @notempty
-             */
-            text: string;
-        }
+    // test('notempty', () => {
+    //     type TestNotempty = {
+    //         /**
+    //          * @notempty
+    //          */
+    //         text: string;
+    //     }
 
-        const TestNotemptyValidator = validate<TestNotempty>($schema<TestNotempty>());
+    //     const TestNotemptyValidator = validate<TestNotempty>($schema<TestNotempty>());
 
-        expect(TestNotemptyValidator({ text: "a" })).toBe(true);
-        expect(TestNotemptyValidator({ text: "123" })).toBe(true);
-        expect(TestNotemptyValidator({ text: "~!+_*" })).toBe(true);
-        expect(TestNotemptyValidator({ text: " " })).toBe(true);
+    //     expect(TestNotemptyValidator({ text: "a" })).toBe(true);
+    //     expect(TestNotemptyValidator({ text: "123" })).toBe(true);
+    //     expect(TestNotemptyValidator({ text: "~!+_*" })).toBe(true);
+    //     expect(TestNotemptyValidator({ text: " " })).toBe(true);
 
-        expect(TestNotemptyValidator({ text: "" })).toBe(false);
-    })
+    //     expect(TestNotemptyValidator({ text: "" })).toBe(false);
+    // })
 })
+
+type TestUnionEmail = {
+    /**
+     * some email
+     * @some email
+     * @email SomeValueHere!
+     */
+    emailOrAlphanumeric: string;
+}
+
+type TestUnionAlphanumeric = {
+    /**
+     * @alphanumeric value
+     */
+    emailOrAlphanumeric: string;
+}
+
+export type TestUnion = TestUnionEmail | TestUnionAlphanumeric;

--- a/tests/validations/string.test.ts
+++ b/tests/validations/string.test.ts
@@ -205,23 +205,23 @@ describe('Test string tags', () => {
          expect(TestEmailOrAlphanumericValidator({ emailOrAlphanumeric: '' })).toBe(false);
     })
 
-    // test('notempty', () => {
-    //     type TestNotempty = {
-    //         /**
-    //          * @notempty
-    //          */
-    //         text: string;
-    //     }
+    test('notempty', () => {
+        type TestNotempty = {
+            /**
+             * @notempty
+             */
+            text: string;
+        }
 
-    //     const TestNotemptyValidator = validate<TestNotempty>($schema<TestNotempty>());
+        const TestNotemptyValidator = validate<TestNotempty>($schema<TestNotempty>());
 
-    //     expect(TestNotemptyValidator({ text: "a" })).toBe(true);
-    //     expect(TestNotemptyValidator({ text: "123" })).toBe(true);
-    //     expect(TestNotemptyValidator({ text: "~!+_*" })).toBe(true);
-    //     expect(TestNotemptyValidator({ text: " " })).toBe(true);
+        expect(TestNotemptyValidator({ text: "a" })).toBe(true);
+        expect(TestNotemptyValidator({ text: "123" })).toBe(true);
+        expect(TestNotemptyValidator({ text: "~!+_*" })).toBe(true);
+        expect(TestNotemptyValidator({ text: " " })).toBe(true);
 
-    //     expect(TestNotemptyValidator({ text: "" })).toBe(false);
-    // })
+        expect(TestNotemptyValidator({ text: "" })).toBe(false);
+    })
 })
 
 type TestUnionEmail = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
-  
 {
   "compilerOptions": {
     "target": "ES2021",
-    "module": "commonjs",
-    "lib": ["ES2021"],
+    "module": "NodeNext",
+    "lib": [
+      "ES2021"
+    ],
     "moduleResolution": "NodeNext",
     "declaration": true,
     "outDir": "./dist",
@@ -11,5 +12,13 @@
     "strict": true,
     "removeComments": true,
   },
-  "exclude": ["./tests", "./test", "./dist", "./node_modules", "./playground", "./examples"]
+  "exclude": [
+    "./tests",
+    "./test",
+    "./dist",
+    "./node_modules",
+    "./playground",
+    "./examples",
+    "./docs"
+  ]
 }


### PR DESCRIPTION
FEAT(json schema ir): Replace intermediate representation with JSON schema
    
The previous intermediate representation was hand-rolled, and new
typescript features or difficult ones (native enums, mapped types) had
poor support. For example, enums-as-keys to a mapped Record<Enum,
string> type failed to compile.

This commit replaces the intermediate representation with JSONSchema, a
known validation format. We use the 'ts-json-schema-generator' on the
frontend to generate JSONSchema based on TypeScript, and 'jsonschema' on
the backend to validate that the schema is correct.

Custom tags are supported via the "fullDescription" option, where the
entire JSDoc is put into the AST and we parse it in the backend. This is
heavyweight and will lead to larger validators, but
ts-json-schema-generator doesn't support arbitrary keys
(https://github.com/vega/ts-json-schema-generator/issues/2281)
